### PR TITLE
feat: Add optional logging of SBOM contents

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Optionally provide the GitHub action bearer token for license resolution.'
     default: ''
     required: false
+  log-bom-contents:
+    description: 'Set to true to log the contents of the generated SBOM'
+    default: 'true'
+    required: false
 runs:
   using: 'node12'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -33,11 +33,13 @@ try {
   const out = core.getInput('out');
   const json = core.getInput('json') != 'false';
   const githubBearerToken = core.getInput('github-bearer-token');
+  const logBomContents = core.getInput('log-bom-contents') == 'true';
 
   console.log('Options:');
   console.log(`  path: ${path}`);
   console.log(`  out: ${out}`);
   console.log(`  json: ${json}`);
+  console.log(`  log-bom-contents: ${logBomContents}`);
 
   let command = `dotnet CycloneDX ${path} --out ${out}`
   if (json) command += ' --json';
@@ -52,12 +54,10 @@ try {
   output = execSync(command, { encoding: 'utf-8' });
   console.log(output);
 
-  console.log('BOM Contents:');
-  if (json) {
-    let bomContents = fs.readFileSync(`${out}/bom.json`).toString('utf8');
-    console.log(bomContents);
-  } else {
-    let bomContents = fs.readFileSync(`${out}/bom.xml`).toString('utf8');
+  if (logBomContents) {
+    console.log('BOM Contents:');
+    const bomFormat = json ? 'json' : 'xml';
+    let bomContents = fs.readFileSync(`${out}/bom.${bomFormat}`).toString('utf8');
     console.log(bomContents);
   }
 } catch (error) {


### PR DESCRIPTION
This commit introduces a new input parameter 'log-bom-contents' for the CycloneDX .NET GitHub action, which allows users to optionally log the contents of the generated SBOM. The behavior is controlled through this input, with a default value of 'true' to maintain existing functionality for current users.

- Updated action.yml to define 'log-bom-contents' input.
- Modified index.js to conditionally log BOM contents based on new input.